### PR TITLE
Add Japanese subtitle to home page header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,12 @@ export default function Home() {
           <p className="text-lg" style={{ color: '#574a46', opacity: 0.7 }}>
             Collaborative markdown editing
           </p>
+          <p
+            className="text-sm mt-1"
+            style={{ color: '#574a46', opacity: 0.5 }}
+          >
+            URLを共有するだけで、誰でも一緒に編集できます
+          </p>
         </header>
         <PageBoard />
       </div>


### PR DESCRIPTION
## Summary
Added a Japanese subtitle to the home page header that explains the core functionality of the collaborative markdown editor in the user's native language.

## Changes
- Added a new paragraph element below the "Collaborative markdown editing" subtitle
- Displays Japanese text: "URLを共有するだけで、誰でも一緒に編集できます" (Share a URL and anyone can edit together)
- Styled with smaller font size (`text-sm`), reduced opacity (0.5), and consistent color scheme matching the existing subtitle
- Added top margin (`mt-1`) for proper spacing

## Details
This change improves accessibility and user experience for Japanese-speaking users by providing a clear explanation of the product's key value proposition in their language. The styling maintains visual hierarchy by using a smaller font size and lower opacity compared to the main subtitle.

https://claude.ai/code/session_01P8pNqBFYMEsQhmtH2njJZp