### PR TITLE
Refactor components to use custom hooks for better separation of concerns

### DIFF
--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -1,300 +1,54 @@
 'use client';
 
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { Editor, rootCtx, defaultValueCtx } from '@milkdown/core';
-import { commonmark } from '@milkdown/preset-commonmark';
-import { listener, listenerCtx } from '@milkdown/plugin-listener';
-import { collab, collabServiceCtx } from '@milkdown/plugin-collab';
-import type { Page } from '@/lib/types';
-import { logger } from '@/lib/logger';
-import { logResponseError } from '@/lib/api';
-import * as Y from 'yjs';
-import { WebsocketProvider } from 'y-websocket';
+import { usePageData } from '@/hooks/usePageData';
+import { useAutoSave } from '@/hooks/useAutoSave';
+import { useCollaborativeEditor } from '@/hooks/useCollaborativeEditor';
 import '../app/milkdown.css';
 
-// Timeout for waiting for Yjs sync to complete (in milliseconds)
-const SYNC_TIMEOUT_MS = 2000;
-
 export default function MarkdownEditor({ pageId }: { pageId: string }) {
-  const [page, setPage] = useState<Page | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const saveErrorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const editorRef = useRef<HTMLDivElement>(null);
-  const editorInstanceRef = useRef<Editor | null>(null);
-  const ydocRef = useRef<Y.Doc | null>(null);
-  const providerRef = useRef<WebsocketProvider | null>(null);
-  const pageRef = useRef<Page | null>(null);
-  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const editorInitializedRef = useRef(false);
   const router = useRouter();
 
-  // Keep pageRef in sync with page state
-  useEffect(() => {
-    pageRef.current = page;
-  }, [page]);
+  const handleNotFound = useCallback(() => {
+    router.push('/');
+  }, [router]);
 
-  const showSaveError = useCallback((message: string) => {
-    setSaveError(message);
-    if (saveErrorTimeoutRef.current) {
-      clearTimeout(saveErrorTimeoutRef.current);
+  const { page, loading } = usePageData(pageId, handleNotFound);
+  const {
+    isSaving,
+    saveError,
+    handleContentChange,
+    cleanup: cleanupSave,
+  } = useAutoSave(pageId);
+  const { initEditor, cleanup: cleanupEditor } = useCollaborativeEditor(
+    pageId,
+    handleContentChange,
+  );
+
+  // Initialize editor when page data arrives
+  useEffect(() => {
+    if (page && editorRef.current && !editorInitializedRef.current) {
+      editorInitializedRef.current = true;
+      // Small delay to ensure DOM is ready
+      const timer = setTimeout(() => {
+        if (editorRef.current) {
+          initEditor(editorRef.current, page.content);
+        }
+      }, 100);
+      return () => clearTimeout(timer);
     }
-    saveErrorTimeoutRef.current = setTimeout(() => {
-      setSaveError(null);
-      saveErrorTimeoutRef.current = null;
-    }, 5000);
-  }, []);
+  }, [page, initEditor]);
 
-  const handleContentChange = useCallback(
-    async (content: string) => {
-      if (!pageRef.current) return;
-
-      logger.log(
-        '[Editor] Content changed - length:',
-        content.length,
-        'preview:',
-        content.substring(0, 50),
-      );
-
-      // Clear existing timeout
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
-
-      // Debounce save by 1 second
-      saveTimeoutRef.current = setTimeout(async () => {
-        logger.log('[Editor] Saving content - length:', content.length);
-        setIsSaving(true);
-
-        try {
-          const response = await fetch(`/api/pages/${pageId}`, {
-            method: 'PATCH',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              content,
-            }),
-          });
-
-          if (!response.ok) {
-            await logResponseError('Editor Save', response);
-            showSaveError(
-              response.status === 413
-                ? '保存できませんでした: コンテンツが大きすぎます（上限: 10MB）'
-                : '保存に失敗しました',
-            );
-          } else {
-            if (saveErrorTimeoutRef.current) {
-              clearTimeout(saveErrorTimeoutRef.current);
-              saveErrorTimeoutRef.current = null;
-            }
-            setSaveError(null);
-            logger.log(
-              '[Editor] Save successful - content length:',
-              content.length,
-            );
-          }
-        } catch (error) {
-          logger.error('[Editor Save] Network error:', error);
-          showSaveError('保存に失敗しました');
-        } finally {
-          setIsSaving(false);
-        }
-      }, 1000);
-    },
-    [pageId, showSaveError],
-  );
-
-  const initEditor = useCallback(
-    async (initialContent: string) => {
-      if (!editorRef.current) return;
-
-      // Prevent double initialization
-      if (editorInstanceRef.current) {
-        logger.log('[Editor] Editor already initialized, skipping');
-        return;
-      }
-
-      logger.log(
-        '[Editor] Initializing editor with SQLite content length:',
-        initialContent?.length || 0,
-      );
-
-      try {
-        // Create Yjs document
-        const ydoc = new Y.Doc();
-        ydocRef.current = ydoc;
-
-        // Connect to WebSocket server for collaborative editing
-        const wsProtocol =
-          window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const wsHost = window.location.hostname;
-        // NEXT_PUBLIC_WS_PORT (optional): public env var to override the default
-        // y-websocket server port. If not set, port 1234 is used.
-        const wsPort = process.env.NEXT_PUBLIC_WS_PORT || '1234';
-        const wsUrl = `${wsProtocol}//${wsHost}:${wsPort}`;
-
-        const provider = new WebsocketProvider(wsUrl, pageId, ydoc);
-        providerRef.current = provider;
-
-        logger.log(`[WebSocket] Connecting to room: ${pageId} at ${wsUrl}`);
-
-        // Wait for initial sync to complete before deciding what to do
-        await new Promise<void>((resolve) => {
-          const handleSync = (isSynced: boolean) => {
-            if (isSynced) {
-              provider.off('sync', handleSync);
-
-              // Check if Yjs document is empty after sync
-              const fragment = ydoc.getXmlFragment('prosemirror');
-              const isEmpty = fragment.length === 0;
-
-              logger.log(
-                '[Yjs] Sync complete. Fragment isEmpty:',
-                isEmpty,
-                'initialContent length:',
-                initialContent?.length || 0,
-              );
-
-              // If Yjs doc is empty AND we have SQLite content, populate Yjs doc directly
-              if (isEmpty && initialContent) {
-                logger.log(
-                  '[Yjs] Populating empty Yjs document with SQLite content',
-                );
-                // Import the markdown content into the Yjs document
-                // The collab plugin will convert markdown to ProseMirror doc structure
-                // For now, we'll use the defaultValueCtx approach but need to ensure
-                // it happens before collab syncs again
-                logger.log('[Yjs] Direct Yjs population - fragment created');
-              } else if (!isEmpty) {
-                logger.log(
-                  '[Yjs] Yjs document has content from another client, ignoring SQLite',
-                );
-              }
-
-              resolve();
-            }
-          };
-
-          provider.on('sync', handleSync);
-
-          // Timeout fallback in case sync takes too long
-          setTimeout(() => {
-            provider.off('sync', handleSync);
-            logger.log('[Yjs] Sync timeout, assuming empty document');
-            resolve();
-          }, SYNC_TIMEOUT_MS);
-        });
-
-        // Determine if we should use SQLite content
-        const fragment = ydoc.getXmlFragment('prosemirror');
-        const shouldUseSQLiteContent =
-          fragment.length === 0 && !!initialContent;
-
-        const editor = await Editor.make()
-          .config((ctx) => {
-            ctx.set(rootCtx, editorRef.current!);
-
-            // Set initial content from SQLite if Yjs document is empty
-            if (shouldUseSQLiteContent) {
-              logger.log(
-                '[Editor] Setting defaultValueCtx with SQLite content',
-              );
-              ctx.set(defaultValueCtx, initialContent);
-            } else {
-              logger.log(
-                '[Editor] NOT setting defaultValueCtx (using Yjs content or empty)',
-              );
-            }
-
-            // Listen to changes
-            ctx.get(listenerCtx).markdownUpdated((ctx, markdown) => {
-              handleContentChange(markdown);
-            });
-          })
-          .use(commonmark)
-          .use(listener)
-          .use(collab)
-          .config((ctx) => {
-            // Configure collab service AFTER loading the plugin
-            const collabService = ctx.get(collabServiceCtx);
-            collabService.bindDoc(ydoc);
-            collabService.setAwareness(provider.awareness);
-          })
-          .create();
-
-        // Connect the collab service AFTER editor is fully created
-        // This is critical - calling connect() before the editor is ready will fail
-        editor.action((ctx) => {
-          ctx.get(collabServiceCtx).connect();
-        });
-
-        editorInstanceRef.current = editor;
-      } catch (error) {
-        logger.error('Failed to initialize editor:', error);
-      }
-    },
-    [pageId, handleContentChange],
-  );
-
+  // Cleanup on unmount
   useEffect(() => {
-    // Fetch page data and initialize editor - only once on mount
-    let isMounted = true;
-
-    const fetchPage = async () => {
-      try {
-        const response = await fetch(`/api/pages/${pageId}`);
-        if (!response.ok) {
-          await logResponseError('Editor FetchPage', response);
-          if (isMounted) router.push('/');
-          return;
-        }
-
-        const data = await response.json();
-        if (!isMounted) return;
-
-        setPage(data);
-        setLoading(false);
-
-        // Initialize editor after page is loaded
-        // Small delay to ensure DOM is ready
-        setTimeout(() => {
-          if (isMounted) {
-            initEditor(data.content);
-          }
-        }, 100);
-      } catch (error) {
-        logger.error('[Editor FetchPage] Network error:', error);
-        if (isMounted) router.push('/');
-      }
-    };
-
-    fetchPage();
-
     return () => {
-      isMounted = false;
-
-      // Cleanup
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
-      if (saveErrorTimeoutRef.current) {
-        clearTimeout(saveErrorTimeoutRef.current);
-      }
-      if (providerRef.current) {
-        providerRef.current.destroy();
-      }
-      if (editorInstanceRef.current) {
-        editorInstanceRef.current.destroy();
-        editorInstanceRef.current = null;
-      }
-      if (ydocRef.current) {
-        ydocRef.current.destroy();
-      }
+      cleanupEditor();
+      cleanupSave();
     };
-  }, [pageId, router, initEditor]);
+  }, [cleanupEditor, cleanupSave]);
 
   if (loading) {
     return (

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback, useRef } from 'react';
-
-const ANIMATION_DURATION_MS = 200;
+import { ANIMATION_DURATION_MS } from '@/lib/constants';
 
 interface ToastProps {
   message: string;

--- a/hooks/useArchiveList.ts
+++ b/hooks/useArchiveList.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+import type { ArchiveListItem } from '@/lib/types';
+import { logger } from '@/lib/logger';
+import { logResponseError } from '@/lib/api';
+
+export function useArchiveList() {
+  const [archives, setArchives] = useState<ArchiveListItem[]>([]);
+
+  const fetchArchives = useCallback(async () => {
+    try {
+      const response = await fetch('/api/archives');
+      if (!response.ok) {
+        await logResponseError('PageBoard FetchArchives', response);
+        return;
+      }
+      const data = await response.json();
+      setArchives(data);
+    } catch (error) {
+      logger.error('[PageBoard FetchArchives] Network error:', error);
+    }
+  }, []);
+
+  const addArchive = useCallback((archive: ArchiveListItem) => {
+    setArchives((prev) => [archive, ...prev]);
+  }, []);
+
+  return { archives, fetchArchives, addArchive };
+}

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -1,0 +1,91 @@
+import { useState, useCallback, useRef } from 'react';
+import { logger } from '@/lib/logger';
+import { logResponseError } from '@/lib/api';
+
+export function useAutoSave(pageId: string) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const saveErrorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const showSaveError = useCallback((message: string) => {
+    setSaveError(message);
+    if (saveErrorTimeoutRef.current) {
+      clearTimeout(saveErrorTimeoutRef.current);
+    }
+    saveErrorTimeoutRef.current = setTimeout(() => {
+      setSaveError(null);
+      saveErrorTimeoutRef.current = null;
+    }, 5000);
+  }, []);
+
+  const handleContentChange = useCallback(
+    (content: string) => {
+      logger.log(
+        '[Editor] Content changed - length:',
+        content.length,
+        'preview:',
+        content.substring(0, 50),
+      );
+
+      // Clear existing timeout
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+
+      // Debounce save by 1 second
+      saveTimeoutRef.current = setTimeout(async () => {
+        logger.log('[Editor] Saving content - length:', content.length);
+        setIsSaving(true);
+
+        try {
+          const response = await fetch(`/api/pages/${pageId}`, {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              content,
+            }),
+          });
+
+          if (!response.ok) {
+            await logResponseError('Editor Save', response);
+            showSaveError(
+              response.status === 413
+                ? '保存できませんでした: コンテンツが大きすぎます（上限: 10MB）'
+                : '保存に失敗しました',
+            );
+          } else {
+            if (saveErrorTimeoutRef.current) {
+              clearTimeout(saveErrorTimeoutRef.current);
+              saveErrorTimeoutRef.current = null;
+            }
+            setSaveError(null);
+            logger.log(
+              '[Editor] Save successful - content length:',
+              content.length,
+            );
+          }
+        } catch (error) {
+          logger.error('[Editor Save] Network error:', error);
+          showSaveError('保存に失敗しました');
+        } finally {
+          setIsSaving(false);
+        }
+      }, 1000);
+    },
+    [pageId, showSaveError],
+  );
+
+  const cleanup = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    if (saveErrorTimeoutRef.current) {
+      clearTimeout(saveErrorTimeoutRef.current);
+    }
+  }, []);
+
+  return { isSaving, saveError, handleContentChange, cleanup };
+}

--- a/hooks/useCollaborativeEditor.ts
+++ b/hooks/useCollaborativeEditor.ts
@@ -1,0 +1,169 @@
+import { useCallback, useRef } from 'react';
+import { Editor, rootCtx, defaultValueCtx } from '@milkdown/core';
+import { commonmark } from '@milkdown/preset-commonmark';
+import { listener, listenerCtx } from '@milkdown/plugin-listener';
+import { collab, collabServiceCtx } from '@milkdown/plugin-collab';
+import { logger } from '@/lib/logger';
+import * as Y from 'yjs';
+import { WebsocketProvider } from 'y-websocket';
+
+// Timeout for waiting for Yjs sync to complete (in milliseconds)
+const SYNC_TIMEOUT_MS = 2000;
+
+export function useCollaborativeEditor(
+  pageId: string,
+  onContentChange: (content: string) => void,
+) {
+  const editorInstanceRef = useRef<Editor | null>(null);
+  const ydocRef = useRef<Y.Doc | null>(null);
+  const providerRef = useRef<WebsocketProvider | null>(null);
+
+  const initEditor = useCallback(
+    async (editorElement: HTMLDivElement, initialContent: string) => {
+      // Prevent double initialization
+      if (editorInstanceRef.current) {
+        logger.log('[Editor] Editor already initialized, skipping');
+        return;
+      }
+
+      logger.log(
+        '[Editor] Initializing editor with SQLite content length:',
+        initialContent?.length || 0,
+      );
+
+      try {
+        // Create Yjs document
+        const ydoc = new Y.Doc();
+        ydocRef.current = ydoc;
+
+        // Connect to WebSocket server for collaborative editing
+        const wsProtocol =
+          window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsHost = window.location.hostname;
+        // NEXT_PUBLIC_WS_PORT (optional): public env var to override the default
+        // y-websocket server port. If not set, port 1234 is used.
+        const wsPort = process.env.NEXT_PUBLIC_WS_PORT || '1234';
+        const wsUrl = `${wsProtocol}//${wsHost}:${wsPort}`;
+
+        const provider = new WebsocketProvider(wsUrl, pageId, ydoc);
+        providerRef.current = provider;
+
+        logger.log(`[WebSocket] Connecting to room: ${pageId} at ${wsUrl}`);
+
+        // Wait for initial sync to complete before deciding what to do
+        await new Promise<void>((resolve) => {
+          let resolved = false;
+
+          const onResolved = () => {
+            if (resolved) return;
+            resolved = true;
+            resolve();
+          };
+
+          const handleSync = (isSynced: boolean) => {
+            if (isSynced) {
+              provider.off('sync', handleSync);
+
+              // Check if Yjs document is empty after sync
+              const fragment = ydoc.getXmlFragment('prosemirror');
+              const isEmpty = fragment.length === 0;
+
+              logger.log(
+                '[Yjs] Sync complete. Fragment isEmpty:',
+                isEmpty,
+                'initialContent length:',
+                initialContent?.length || 0,
+              );
+
+              // If Yjs doc is empty AND we have SQLite content, populate Yjs doc directly
+              if (isEmpty && initialContent) {
+                logger.log(
+                  '[Yjs] Populating empty Yjs document with SQLite content',
+                );
+                logger.log('[Yjs] Direct Yjs population - fragment created');
+              } else if (!isEmpty) {
+                logger.log(
+                  '[Yjs] Yjs document has content from another client, ignoring SQLite',
+                );
+              }
+
+              onResolved();
+            }
+          };
+
+          provider.on('sync', handleSync);
+
+          // Timeout fallback in case sync takes too long
+          setTimeout(() => {
+            provider.off('sync', handleSync);
+            logger.log('[Yjs] Sync timeout, assuming empty document');
+            onResolved();
+          }, SYNC_TIMEOUT_MS);
+        });
+
+        // Determine if we should use SQLite content
+        const fragment = ydoc.getXmlFragment('prosemirror');
+        const shouldUseSQLiteContent =
+          fragment.length === 0 && !!initialContent;
+
+        const editor = await Editor.make()
+          .config((ctx) => {
+            ctx.set(rootCtx, editorElement);
+
+            // Set initial content from SQLite if Yjs document is empty
+            if (shouldUseSQLiteContent) {
+              logger.log(
+                '[Editor] Setting defaultValueCtx with SQLite content',
+              );
+              ctx.set(defaultValueCtx, initialContent);
+            } else {
+              logger.log(
+                '[Editor] NOT setting defaultValueCtx (using Yjs content or empty)',
+              );
+            }
+
+            // Listen to changes
+            ctx.get(listenerCtx).markdownUpdated((ctx, markdown) => {
+              onContentChange(markdown);
+            });
+          })
+          .use(commonmark)
+          .use(listener)
+          .use(collab)
+          .config((ctx) => {
+            // Configure collab service AFTER loading the plugin
+            const collabService = ctx.get(collabServiceCtx);
+            collabService.bindDoc(ydoc);
+            collabService.setAwareness(provider.awareness);
+          })
+          .create();
+
+        // Connect the collab service AFTER editor is fully created
+        // This is critical - calling connect() before the editor is ready will fail
+        editor.action((ctx) => {
+          ctx.get(collabServiceCtx).connect();
+        });
+
+        editorInstanceRef.current = editor;
+      } catch (error) {
+        logger.error('Failed to initialize editor:', error);
+      }
+    },
+    [pageId, onContentChange],
+  );
+
+  const cleanup = useCallback(() => {
+    if (providerRef.current) {
+      providerRef.current.destroy();
+    }
+    if (editorInstanceRef.current) {
+      editorInstanceRef.current.destroy();
+      editorInstanceRef.current = null;
+    }
+    if (ydocRef.current) {
+      ydocRef.current.destroy();
+    }
+  }, []);
+
+  return { initEditor, cleanup };
+}

--- a/hooks/useItemAnimation.ts
+++ b/hooks/useItemAnimation.ts
@@ -1,0 +1,65 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { ANIMATION_DURATION_MS } from '@/lib/constants';
+
+interface AnimatingItem {
+  id: string;
+  type: 'fadeOut' | 'fadeIn';
+}
+
+export function useItemAnimation() {
+  const [animatingItems, setAnimatingItems] = useState<AnimatingItem[]>([]);
+  const timersRef = useRef<Set<NodeJS.Timeout>>(new Set());
+
+  // Cleanup timers on unmount to prevent memory leaks
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  const startFadeOut = useCallback((id: string) => {
+    setAnimatingItems((prev) => [...prev, { id, type: 'fadeOut' }]);
+  }, []);
+
+  const startFadeIn = useCallback((id: string) => {
+    setAnimatingItems((prev) => [
+      ...prev.filter((item) => item.id !== id),
+      { id, type: 'fadeIn' },
+    ]);
+  }, []);
+
+  const clearAnimation = useCallback((id: string) => {
+    setAnimatingItems((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const getItemOpacity = useCallback(
+    (id: string) => {
+      const animating = animatingItems.find((item) => item.id === id);
+      if (!animating) return 1;
+      return animating.type === 'fadeOut' ? 0 : 1;
+    },
+    [animatingItems],
+  );
+
+  const scheduleAfterAnimation = useCallback(
+    (callback: () => void): NodeJS.Timeout => {
+      const timer = setTimeout(() => {
+        timersRef.current.delete(timer);
+        callback();
+      }, ANIMATION_DURATION_MS);
+      timersRef.current.add(timer);
+      return timer;
+    },
+    [],
+  );
+
+  return {
+    getItemOpacity,
+    startFadeOut,
+    startFadeIn,
+    clearAnimation,
+    scheduleAfterAnimation,
+  };
+}

--- a/hooks/usePageData.ts
+++ b/hooks/usePageData.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Page } from '@/lib/types';
+import { logger } from '@/lib/logger';
+import { logResponseError } from '@/lib/api';
+
+export function usePageData(pageId: string, onNotFound: () => void) {
+  const [page, setPage] = useState<Page | null>(null);
+  const [loading, setLoading] = useState(true);
+  const onNotFoundRef = useRef(onNotFound);
+
+  useEffect(() => {
+    onNotFoundRef.current = onNotFound;
+  }, [onNotFound]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchPage = async () => {
+      try {
+        const response = await fetch(`/api/pages/${pageId}`);
+        if (!response.ok) {
+          await logResponseError('Editor FetchPage', response);
+          if (isMounted) onNotFoundRef.current();
+          return;
+        }
+
+        const data = await response.json();
+        if (!isMounted) return;
+
+        setPage(data);
+        setLoading(false);
+      } catch (error) {
+        logger.error('[Editor FetchPage] Network error:', error);
+        if (isMounted) onNotFoundRef.current();
+      }
+    };
+
+    fetchPage();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [pageId]);
+
+  return { page, loading };
+}

--- a/hooks/usePageList.ts
+++ b/hooks/usePageList.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+import type { PageListItem } from '@/lib/types';
+import { logger } from '@/lib/logger';
+import { logResponseError } from '@/lib/api';
+
+export function usePageList() {
+  const [pages, setPages] = useState<PageListItem[]>([]);
+
+  const fetchPages = useCallback(async () => {
+    try {
+      const response = await fetch('/api/pages');
+      if (!response.ok) {
+        await logResponseError('PageBoard FetchPages', response);
+        return;
+      }
+      const data = await response.json();
+      setPages(data);
+    } catch (error) {
+      logger.error('[PageBoard FetchPages] Network error:', error);
+    }
+  }, []);
+
+  const removePage = useCallback((id: string) => {
+    setPages((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  return { pages, fetchPages, removePage };
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,2 @@
+/** Duration of fade in/out animations in milliseconds */
+export const ANIMATION_DURATION_MS = 200;

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,8 @@
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -40,11 +42,26 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "eslint-config-prettier": "^10.1.8",
+        "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "tailwindcss": "^4",
         "typescript": "5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -58,6 +75,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -251,6 +323,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -297,6 +379,138 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
+      "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -916,6 +1130,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
+      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2548,6 +2780,93 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2558,6 +2877,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -3410,6 +3737,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3758,6 +4095,16 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -4094,6 +4441,53 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4107,6 +4501,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4178,6 +4586,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -4318,6 +4733,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4403,6 +4826,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/errno": {
@@ -5628,6 +6064,47 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5690,6 +6167,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -6010,6 +6497,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6225,6 +6719,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
+      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^5.3.7",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.20.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -6835,6 +7369,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6941,6 +7486,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7420,6 +7972,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -7880,6 +8442,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8074,6 +8649,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8340,6 +8953,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8450,6 +9077,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8664,6 +9301,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9160,6 +9810,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9223,6 +9886,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
@@ -9348,6 +10018,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.22"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9359,6 +10049,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -9583,6 +10299,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
+      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -10002,6 +10728,54 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10177,6 +10951,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
   "devDependencies": {
     "@playwright/test": "^1.58.1",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -48,6 +50,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
+    "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4",
     "typescript": "5.9.3",

--- a/tests/hooks/useArchiveList.test.ts
+++ b/tests/hooks/useArchiveList.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useArchiveList } from '@/hooks/useArchiveList';
+import type { ArchiveListItem } from '@/lib/types';
+
+const mockArchives: ArchiveListItem[] = [
+  {
+    id: '1',
+    title: 'Archive 1',
+    created_at: 1000,
+    updated_at: 2000,
+    archived_at: 3000,
+  },
+  {
+    id: '2',
+    title: 'Archive 2',
+    created_at: 1100,
+    updated_at: 2100,
+    archived_at: 3100,
+  },
+];
+
+describe('useArchiveList', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with empty archives array', () => {
+    const { result } = renderHook(() => useArchiveList());
+    expect(result.current.archives).toEqual([]);
+  });
+
+  describe('fetchArchives', () => {
+    it('fetches and sets archives on success', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockArchives,
+      } as Response);
+
+      const { result } = renderHook(() => useArchiveList());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      expect(result.current.archives).toEqual(mockArchives);
+      expect(fetch).toHaveBeenCalledWith('/api/archives');
+    });
+
+    it('does not update archives on error response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => 'error',
+      } as Response);
+
+      const { result } = renderHook(() => useArchiveList());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      expect(result.current.archives).toEqual([]);
+    });
+
+    it('does not update archives on network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      const { result } = renderHook(() => useArchiveList());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      expect(result.current.archives).toEqual([]);
+    });
+  });
+
+  describe('addArchive', () => {
+    it('adds an archive to the beginning of the list', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockArchives,
+      } as Response);
+
+      const { result } = renderHook(() => useArchiveList());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      const newArchive: ArchiveListItem = {
+        id: '3',
+        title: 'New Archive',
+        created_at: 1200,
+        updated_at: 2200,
+        archived_at: 3200,
+      };
+
+      act(() => {
+        result.current.addArchive(newArchive);
+      });
+
+      expect(result.current.archives).toHaveLength(3);
+      expect(result.current.archives[0]).toEqual(newArchive);
+    });
+
+    it('adds an archive to an empty list', () => {
+      const { result } = renderHook(() => useArchiveList());
+
+      const newArchive: ArchiveListItem = {
+        id: '1',
+        title: 'First Archive',
+        created_at: 1000,
+        updated_at: 2000,
+        archived_at: 3000,
+      };
+
+      act(() => {
+        result.current.addArchive(newArchive);
+      });
+
+      expect(result.current.archives).toHaveLength(1);
+      expect(result.current.archives[0]).toEqual(newArchive);
+    });
+  });
+
+  describe('reference stability', () => {
+    it('returns stable fetchArchives reference', () => {
+      const { result, rerender } = renderHook(() => useArchiveList());
+      const first = result.current.fetchArchives;
+      rerender();
+      expect(result.current.fetchArchives).toBe(first);
+    });
+
+    it('returns stable addArchive reference', () => {
+      const { result, rerender } = renderHook(() => useArchiveList());
+      const first = result.current.addArchive;
+      rerender();
+      expect(result.current.addArchive).toBe(first);
+    });
+  });
+});

--- a/tests/hooks/useAutoSave.test.ts
+++ b/tests/hooks/useAutoSave.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAutoSave } from '@/hooks/useAutoSave';
+
+describe('useAutoSave', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with isSaving false and no error', () => {
+    const { result } = renderHook(() => useAutoSave('page-1'));
+    expect(result.current.isSaving).toBe(false);
+    expect(result.current.saveError).toBeNull();
+  });
+
+  describe('handleContentChange', () => {
+    it('debounces save by 1 second', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('hello');
+      });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith('/api/pages/page-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'hello' }),
+      });
+    });
+
+    it('cancels previous debounce when called again', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('first');
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      act(() => {
+        result.current.handleContentChange('second');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // Only the second call should have been saved
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('/api/pages/page-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'second' }),
+      });
+    });
+
+    it('sets isSaving during save', async () => {
+      let resolvePromise: (value: Response) => void;
+      vi.spyOn(globalThis, 'fetch').mockReturnValue(
+        new Promise<Response>((resolve) => {
+          resolvePromise = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('content');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.isSaving).toBe(true);
+
+      await act(async () => {
+        resolvePromise!({
+          ok: true,
+          json: async () => ({ success: true }),
+        } as Response);
+      });
+
+      expect(result.current.isSaving).toBe(false);
+    });
+
+    it('shows error on failed save', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => 'error',
+      } as Response);
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('content');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.saveError).toBe('保存に失敗しました');
+    });
+
+    it('shows specific error for 413 status', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 413,
+        statusText: 'Content Too Large',
+        text: async () => 'too large',
+      } as Response);
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('content');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.saveError).toBe(
+        '保存できませんでした: コンテンツが大きすぎます（上限: 10MB）',
+      );
+    });
+
+    it('shows error on network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+        new Error('Network error'),
+      );
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('content');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.saveError).toBe('保存に失敗しました');
+    });
+
+    it('clears error on successful save after error', async () => {
+      // First save fails
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => 'error',
+      } as Response);
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('content');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.saveError).toBe('保存に失敗しました');
+
+      // Second save succeeds
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
+
+      act(() => {
+        result.current.handleContentChange('fixed content');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.saveError).toBeNull();
+    });
+
+    it('auto-dismisses save error after 5 seconds', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => 'error',
+      } as Response);
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('content');
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.saveError).toBe('保存に失敗しました');
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(result.current.saveError).toBeNull();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('clears pending save timeout', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
+
+      const { result } = renderHook(() => useAutoSave('page-1'));
+
+      act(() => {
+        result.current.handleContentChange('content');
+      });
+
+      act(() => {
+        result.current.cleanup();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // Save should not have been triggered
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reference stability', () => {
+    it('returns stable handleContentChange reference', () => {
+      const { result, rerender } = renderHook(() => useAutoSave('page-1'));
+      const first = result.current.handleContentChange;
+      rerender();
+      expect(result.current.handleContentChange).toBe(first);
+    });
+
+    it('returns stable cleanup reference', () => {
+      const { result, rerender } = renderHook(() => useAutoSave('page-1'));
+      const first = result.current.cleanup;
+      rerender();
+      expect(result.current.cleanup).toBe(first);
+    });
+  });
+});

--- a/tests/hooks/useItemAnimation.test.ts
+++ b/tests/hooks/useItemAnimation.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useItemAnimation } from '@/hooks/useItemAnimation';
+
+describe('useItemAnimation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initializes with no animations', () => {
+    const { result } = renderHook(() => useItemAnimation());
+    expect(result.current.getItemOpacity('any-id')).toBe(1);
+  });
+
+  describe('startFadeOut', () => {
+    it('sets opacity to 0 for fade out animation', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeOut('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+    });
+
+    it('does not affect other items', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeOut('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-2')).toBe(1);
+    });
+  });
+
+  describe('startFadeIn', () => {
+    it('sets opacity to 1 for fade in animation', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeIn('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+
+    it('replaces existing animation for the same item', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeOut('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+
+      act(() => {
+        result.current.startFadeIn('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+  });
+
+  describe('clearAnimation', () => {
+    it('removes animation and restores default opacity', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeOut('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+
+      act(() => {
+        result.current.clearAnimation('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+
+    it('does not affect other animated items', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeOut('item-1');
+        result.current.startFadeOut('item-2');
+      });
+
+      act(() => {
+        result.current.clearAnimation('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+      expect(result.current.getItemOpacity('item-2')).toBe(0);
+    });
+  });
+
+  describe('scheduleAfterAnimation', () => {
+    it('calls callback after animation duration (200ms)', () => {
+      const { result } = renderHook(() => useItemAnimation());
+      const callback = vi.fn();
+
+      act(() => {
+        result.current.scheduleAfterAnimation(callback);
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(callback).toHaveBeenCalledOnce();
+    });
+
+    it('does not call callback before animation duration', () => {
+      const { result } = renderHook(() => useItemAnimation());
+      const callback = vi.fn();
+
+      act(() => {
+        result.current.scheduleAfterAnimation(callback);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(199);
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple scheduled animations independently', () => {
+      const { result } = renderHook(() => useItemAnimation());
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      act(() => {
+        result.current.scheduleAfterAnimation(callback1);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        result.current.scheduleAfterAnimation(callback2);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(callback1).toHaveBeenCalledOnce();
+      expect(callback2).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(callback2).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('clears pending timers when unmounted', () => {
+      const { result, unmount } = renderHook(() => useItemAnimation());
+      const callback = vi.fn();
+
+      act(() => {
+        result.current.scheduleAfterAnimation(callback);
+      });
+
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      // Timer was cleared on unmount, callback should not fire
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getItemOpacity', () => {
+    it('returns 1 for non-animated items', () => {
+      const { result } = renderHook(() => useItemAnimation());
+      expect(result.current.getItemOpacity('unknown')).toBe(1);
+    });
+
+    it('returns 0 for fade out items', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeOut('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+    });
+
+    it('returns 1 for fade in items', () => {
+      const { result } = renderHook(() => useItemAnimation());
+
+      act(() => {
+        result.current.startFadeIn('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+  });
+
+  describe('reference stability', () => {
+    it('returns stable startFadeOut reference', () => {
+      const { result, rerender } = renderHook(() => useItemAnimation());
+      const first = result.current.startFadeOut;
+      rerender();
+      expect(result.current.startFadeOut).toBe(first);
+    });
+
+    it('returns stable startFadeIn reference', () => {
+      const { result, rerender } = renderHook(() => useItemAnimation());
+      const first = result.current.startFadeIn;
+      rerender();
+      expect(result.current.startFadeIn).toBe(first);
+    });
+
+    it('returns stable clearAnimation reference', () => {
+      const { result, rerender } = renderHook(() => useItemAnimation());
+      const first = result.current.clearAnimation;
+      rerender();
+      expect(result.current.clearAnimation).toBe(first);
+    });
+
+    it('returns stable scheduleAfterAnimation reference', () => {
+      const { result, rerender } = renderHook(() => useItemAnimation());
+      const first = result.current.scheduleAfterAnimation;
+      rerender();
+      expect(result.current.scheduleAfterAnimation).toBe(first);
+    });
+  });
+});

--- a/tests/hooks/usePageData.test.ts
+++ b/tests/hooks/usePageData.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePageData } from '@/hooks/usePageData';
+import type { Page } from '@/lib/types';
+
+const mockPage: Page = {
+  id: 'page-1',
+  title: 'Test Page',
+  content: '# Hello',
+  created_at: 1000,
+  updated_at: 2000,
+  archived_at: null,
+};
+
+describe('usePageData', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with loading true and null page', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}));
+    const onNotFound = vi.fn();
+    const { result } = renderHook(() => usePageData('page-1', onNotFound));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.page).toBeNull();
+  });
+
+  it('fetches page data on mount', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockPage,
+    } as Response);
+
+    const onNotFound = vi.fn();
+    const { result } = renderHook(() => usePageData('page-1', onNotFound));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.page).toEqual(mockPage);
+    expect(fetch).toHaveBeenCalledWith('/api/pages/page-1');
+    expect(onNotFound).not.toHaveBeenCalled();
+  });
+
+  it('calls onNotFound when page is not found', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => 'not found',
+    } as Response);
+
+    const onNotFound = vi.fn();
+    renderHook(() => usePageData('non-existent', onNotFound));
+
+    await waitFor(() => {
+      expect(onNotFound).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('calls onNotFound on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('Network error'),
+    );
+
+    const onNotFound = vi.fn();
+    renderHook(() => usePageData('page-1', onNotFound));
+
+    await waitFor(() => {
+      expect(onNotFound).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('re-fetches when pageId changes', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockPage,
+    } as Response);
+
+    const onNotFound = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ pageId }) => usePageData(pageId, onNotFound),
+      { initialProps: { pageId: 'page-1' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const secondPage: Page = { ...mockPage, id: 'page-2', title: 'Page 2' };
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => secondPage,
+    } as Response);
+
+    rerender({ pageId: 'page-2' });
+
+    await waitFor(() => {
+      expect(result.current.page?.id).toBe('page-2');
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/pages/page-2');
+  });
+
+  it('does not re-fetch when onNotFound changes', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockPage,
+    } as Response);
+
+    const onNotFound1 = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ onNotFound }) => usePageData('page-1', onNotFound),
+      { initialProps: { onNotFound: onNotFound1 } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const onNotFound2 = vi.fn();
+    rerender({ onNotFound: onNotFound2 });
+
+    // Only one fetch should have been made
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/hooks/usePageList.test.ts
+++ b/tests/hooks/usePageList.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePageList } from '@/hooks/usePageList';
+import type { PageListItem } from '@/lib/types';
+
+const mockPages: PageListItem[] = [
+  { id: '1', title: 'Page 1', created_at: 1000, updated_at: 2000 },
+  { id: '2', title: 'Page 2', created_at: 1100, updated_at: 2100 },
+  { id: '3', title: 'Page 3', created_at: 1200, updated_at: 2200 },
+];
+
+describe('usePageList', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with empty pages array', () => {
+    const { result } = renderHook(() => usePageList());
+    expect(result.current.pages).toEqual([]);
+  });
+
+  describe('fetchPages', () => {
+    it('fetches and sets pages on success', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPages,
+      } as Response);
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toEqual(mockPages);
+      expect(fetch).toHaveBeenCalledWith('/api/pages');
+    });
+
+    it('does not update pages on error response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => 'error',
+      } as Response);
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toEqual([]);
+    });
+
+    it('does not update pages on network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toEqual([]);
+    });
+  });
+
+  describe('removePage', () => {
+    it('removes a page by id', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPages,
+      } as Response);
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toHaveLength(3);
+
+      act(() => {
+        result.current.removePage('2');
+      });
+
+      expect(result.current.pages).toHaveLength(2);
+      expect(result.current.pages.find((p) => p.id === '2')).toBeUndefined();
+    });
+
+    it('does nothing when removing non-existent page', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPages,
+      } as Response);
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      act(() => {
+        result.current.removePage('non-existent');
+      });
+
+      expect(result.current.pages).toHaveLength(3);
+    });
+  });
+
+  describe('fetchPages stability', () => {
+    it('returns a stable fetchPages reference', () => {
+      const { result, rerender } = renderHook(() => usePageList());
+      const firstFetchPages = result.current.fetchPages;
+      rerender();
+      expect(result.current.fetchPages).toBe(firstFetchPages);
+    });
+
+    it('returns a stable removePage reference', () => {
+      const { result, rerender } = renderHook(() => usePageList());
+      const firstRemovePage = result.current.removePage;
+      rerender();
+      expect(result.current.removePage).toBe(firstRemovePage);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR refactors the `MarkdownEditor` and `PageBoard` components by extracting complex logic into reusable custom hooks. This improves code maintainability, testability, and readability while reducing component complexity.

## Key Changes

### New Custom Hooks
- **`usePageData`**: Handles fetching page data from the API with error handling and navigation on failure
- **`useAutoSave`**: Manages debounced content saving with error display and timeout handling
- **`useCollaborativeEditor`**: Encapsulates Milkdown editor initialization with Yjs collaborative editing setup
- **`usePageList`**: Manages page list state and fetching with helper methods for mutations
- **`useArchiveList`**: Manages archive list state and fetching with helper methods for mutations
- **`useItemAnimation`**: Handles fade in/out animations with timer management and cleanup

### Component Refactoring
- **`MarkdownEditor.tsx`**: Reduced from 300 to 54 lines by delegating logic to hooks
  - Removed direct state management for page, saving, and editor initialization
  - Simplified to focus on rendering and orchestrating hooks
  - Improved cleanup with explicit hook cleanup functions

- **`PageBoard.tsx`**: Simplified by extracting animation and data fetching logic
  - Removed inline animation state management
  - Delegated page/archive list operations to dedicated hooks
  - Cleaner archive/unarchive workflows

- **`Toast.tsx`**: Updated to use shared animation constant

### New Files
- **`lib/constants.ts`**: Centralized animation duration constant to avoid duplication

## Implementation Details
- All hooks follow React best practices with proper cleanup and dependency arrays
- Timer management is centralized in `useItemAnimation` to prevent memory leaks
- Error handling and logging patterns are preserved from original implementation
- Callback refs are used where necessary to maintain closure correctness (e.g., `usePageData`)
- The collaborative editor initialization logic remains unchanged but is now isolated and testable

https://claude.ai/code/session_015ivAbU3CHPBNAc9NdABdFR