### PR TITLE
refactor: extract business logic from PageBoard and MarkdownEditor into custom hooks (#46)

### DIFF
--- a/hooks/useAnimatingItems.ts
+++ b/hooks/useAnimatingItems.ts
@@ -1,0 +1,64 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { ANIMATION_DURATION_MS } from '@/lib/constants';
+
+interface AnimatingItem {
+  id: string;
+  type: 'fadeOut' | 'fadeIn';
+}
+
+export function useAnimatingItems() {
+  const [animatingItems, setAnimatingItems] = useState<AnimatingItem[]>([]);
+  const timersRef = useRef<Set<NodeJS.Timeout>>(new Set());
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  const scheduleTimer = useCallback((callback: () => void): void => {
+    const timer = setTimeout(() => {
+      timersRef.current.delete(timer);
+      callback();
+    }, ANIMATION_DURATION_MS);
+    timersRef.current.add(timer);
+  }, []);
+
+  const startFadeOut = useCallback(
+    (id: string, onComplete: () => void) => {
+      setAnimatingItems((prev) => [...prev, { id, type: 'fadeOut' }]);
+      scheduleTimer(onComplete);
+    },
+    [scheduleTimer],
+  );
+
+  const startFadeIn = useCallback(
+    (id: string) => {
+      setAnimatingItems((prev) => [
+        ...prev.filter((item) => item.id !== id),
+        { id, type: 'fadeIn' },
+      ]);
+      scheduleTimer(() => {
+        setAnimatingItems((prev) => prev.filter((item) => item.id !== id));
+      });
+    },
+    [scheduleTimer],
+  );
+
+  const clearAnimation = useCallback((id: string) => {
+    setAnimatingItems((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const getItemOpacity = useCallback(
+    (id: string): number => {
+      const animating = animatingItems.find((item) => item.id === id);
+      if (!animating) return 1;
+      return animating.type === 'fadeOut' ? 0 : 1;
+    },
+    [animatingItems],
+  );
+
+  return { startFadeOut, startFadeIn, clearAnimation, getItemOpacity };
+}

--- a/hooks/useArchiveToast.ts
+++ b/hooks/useArchiveToast.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+interface ArchiveToastState {
+  visible: boolean;
+  pageId: string;
+  pageTitle: string;
+}
+
+export function useArchiveToast() {
+  const [toast, setToast] = useState<ArchiveToastState>({
+    visible: false,
+    pageId: '',
+    pageTitle: '',
+  });
+
+  const showToast = useCallback((pageId: string, pageTitle: string) => {
+    setToast({ visible: true, pageId, pageTitle });
+  }, []);
+
+  const hideToast = useCallback(() => {
+    setToast({ visible: false, pageId: '', pageTitle: '' });
+  }, []);
+
+  return { toast, showToast, hideToast };
+}

--- a/hooks/useArchives.ts
+++ b/hooks/useArchives.ts
@@ -1,0 +1,103 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { ArchiveListItem } from '@/lib/types';
+import { logger } from '@/lib/logger';
+import {
+  logResponseError,
+  isArchiveListItemArray,
+  isArchivePageResponse,
+} from '@/lib/api';
+
+export function useArchives() {
+  const [archives, setArchives] = useState<ArchiveListItem[]>([]);
+  const archivesRef = useRef<ArchiveListItem[]>([]);
+
+  useEffect(() => {
+    archivesRef.current = archives;
+  }, [archives]);
+
+  const fetchArchives = useCallback(async () => {
+    try {
+      const response = await fetch('/api/archives');
+      if (!response.ok) {
+        await logResponseError('PageBoard FetchArchives', response);
+        return;
+      }
+      const data: unknown = await response.json();
+      if (!isArchiveListItemArray(data)) {
+        logger.error(
+          '[PageBoard FetchArchives] Unexpected response shape:',
+          data,
+        );
+        return;
+      }
+      setArchives(data);
+    } catch (error) {
+      logger.error('[PageBoard FetchArchives] Network error:', error);
+    }
+  }, []);
+
+  const archivePage = useCallback(
+    async (id: string): Promise<number | null> => {
+      try {
+        const response = await fetch(`/api/pages/${id}/archive`, {
+          method: 'POST',
+        });
+        if (!response.ok) {
+          await logResponseError('PageBoard ArchivePage', response);
+          return null;
+        }
+        const data: unknown = await response.json();
+        if (!isArchivePageResponse(data)) {
+          logger.error(
+            '[PageBoard ArchivePage] Unexpected response shape:',
+            data,
+          );
+          return null;
+        }
+        return data.archived_at;
+      } catch (error) {
+        logger.error('[PageBoard ArchivePage] Network error:', error);
+        return null;
+      }
+    },
+    [],
+  );
+
+  const unarchivePage = useCallback(async (id: string): Promise<boolean> => {
+    try {
+      const response = await fetch(`/api/pages/${id}/unarchive`, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        await logResponseError('PageBoard UnarchivePage', response);
+        return false;
+      }
+      return true;
+    } catch (error) {
+      logger.error('[PageBoard UnarchivePage] Network error:', error);
+      return false;
+    }
+  }, []);
+
+  const addArchive = useCallback((archive: ArchiveListItem) => {
+    setArchives((prev) => [archive, ...prev]);
+  }, []);
+
+  const removeArchive = useCallback((id: string) => {
+    setArchives((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  const findArchive = useCallback((id: string) => {
+    return archivesRef.current.find((p) => p.id === id);
+  }, []);
+
+  return {
+    archives,
+    fetchArchives,
+    archivePage,
+    unarchivePage,
+    addArchive,
+    removeArchive,
+    findArchive,
+  };
+}

--- a/hooks/usePageList.ts
+++ b/hooks/usePageList.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { PageListItem } from '@/lib/types';
+import { logger } from '@/lib/logger';
+import {
+  logResponseError,
+  isPageListItemArray,
+  isCreatePageResponse,
+} from '@/lib/api';
+
+export function usePageList() {
+  const [pages, setPages] = useState<PageListItem[]>([]);
+  const pagesRef = useRef<PageListItem[]>([]);
+
+  useEffect(() => {
+    pagesRef.current = pages;
+  }, [pages]);
+
+  const fetchPages = useCallback(async () => {
+    try {
+      const response = await fetch('/api/pages');
+      if (!response.ok) {
+        await logResponseError('PageBoard FetchPages', response);
+        return;
+      }
+      const data: unknown = await response.json();
+      if (!isPageListItemArray(data)) {
+        logger.error('[PageBoard FetchPages] Unexpected response shape:', data);
+        return;
+      }
+      setPages(data);
+    } catch (error) {
+      logger.error('[PageBoard FetchPages] Network error:', error);
+    }
+  }, []);
+
+  const createPage = useCallback(async (): Promise<string | null> => {
+    try {
+      const response = await fetch('/api/pages', {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        await logResponseError('PageBoard CreatePage', response);
+        return null;
+      }
+      const data: unknown = await response.json();
+      if (!isCreatePageResponse(data)) {
+        logger.error('[PageBoard CreatePage] Unexpected response shape:', data);
+        return null;
+      }
+      return data.id;
+    } catch (error) {
+      logger.error('[PageBoard CreatePage] Network error:', error);
+      return null;
+    }
+  }, []);
+
+  const removePage = useCallback((id: string) => {
+    setPages((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  const addPage = useCallback((page: PageListItem) => {
+    setPages((prev) => [page, ...prev]);
+  }, []);
+
+  const findPage = useCallback((id: string) => {
+    return pagesRef.current.find((p) => p.id === id);
+  }, []);
+
+  return { pages, fetchPages, createPage, removePage, addPage, findPage };
+}

--- a/hooks/useSaveContent.ts
+++ b/hooks/useSaveContent.ts
@@ -1,0 +1,98 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { logger } from '@/lib/logger';
+import { logResponseError } from '@/lib/api';
+
+export function useSaveContent(pageId: string) {
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const saveErrorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isMountedRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+      if (saveErrorTimeoutRef.current) {
+        clearTimeout(saveErrorTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const showSaveError = useCallback((message: string) => {
+    setSaveError(message);
+    if (saveErrorTimeoutRef.current) {
+      clearTimeout(saveErrorTimeoutRef.current);
+    }
+    saveErrorTimeoutRef.current = setTimeout(() => {
+      setSaveError(null);
+      saveErrorTimeoutRef.current = null;
+    }, 5000);
+  }, []);
+
+  const handleContentChange = useCallback(
+    (content: string) => {
+      logger.log(
+        '[Editor] Content changed - length:',
+        content.length,
+        'preview:',
+        content.substring(0, 50),
+      );
+
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+
+      saveTimeoutRef.current = setTimeout(async () => {
+        if (!isMountedRef.current) return;
+
+        logger.log('[Editor] Saving content - length:', content.length);
+
+        try {
+          const response = await fetch(`/api/pages/${pageId}`, {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              content,
+            }),
+          });
+
+          if (!response.ok) {
+            await logResponseError('Editor Save', response);
+            if (isMountedRef.current) {
+              showSaveError(
+                response.status === 413
+                  ? '保存できませんでした: コンテンツが大きすぎます（上限: 10MB）'
+                  : '保存に失敗しました',
+              );
+            }
+          } else {
+            if (isMountedRef.current) {
+              if (saveErrorTimeoutRef.current) {
+                clearTimeout(saveErrorTimeoutRef.current);
+                saveErrorTimeoutRef.current = null;
+              }
+              setSaveError(null);
+            }
+            logger.log(
+              '[Editor] Save successful - content length:',
+              content.length,
+            );
+          }
+        } catch (error) {
+          logger.error('[Editor Save] Network error:', error);
+          if (isMountedRef.current) {
+            showSaveError('保存に失敗しました');
+          }
+        }
+      }, 1000);
+    },
+    [pageId, showSaveError],
+  );
+
+  return { saveError, handleContentChange };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -40,11 +41,19 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "eslint-config-prettier": "^10.1.8",
+        "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "tailwindcss": "^4",
         "typescript": "5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -58,6 +67,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -90,7 +154,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -252,6 +315,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -298,6 +371,138 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
+      "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -917,6 +1122,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
+      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1835,7 +2058,6 @@
       "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.1"
       },
@@ -2550,6 +2772,66 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2560,6 +2842,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -2663,7 +2953,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2729,7 +3018,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3397,7 +3685,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3413,6 +3700,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3763,6 +4060,16 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -3827,7 +4134,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4100,6 +4406,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4113,6 +4459,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4184,6 +4544,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -4324,6 +4691,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4409,6 +4784,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/errno": {
@@ -4678,7 +5066,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4880,7 +5267,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5636,6 +6022,47 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6018,6 +6445,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6233,6 +6667,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
+      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^5.3.7",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.20.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -6843,6 +7317,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6949,6 +7434,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7888,6 +8380,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8083,6 +8588,44 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8175,7 +8718,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -8196,7 +8738,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -8230,7 +8771,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.5.tgz",
       "integrity": "sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -8314,7 +8854,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8324,7 +8863,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8463,6 +9001,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8677,6 +9225,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9237,6 +9798,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -9344,7 +9912,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9362,6 +9929,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.22"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9373,6 +9960,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -9548,7 +10161,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9598,6 +10210,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
+      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -9805,7 +10427,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9914,7 +10535,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10018,6 +10638,54 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10195,6 +10863,23 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -10253,7 +10938,6 @@
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
       "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -10338,7 +11022,6 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
       "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -10370,7 +11053,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.1",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -48,6 +49,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
+    "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4",
     "typescript": "5.9.3",

--- a/tests/hooks/useAnimatingItems.test.tsx
+++ b/tests/hooks/useAnimatingItems.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAnimatingItems } from '@/hooks/useAnimatingItems';
+import { ANIMATION_DURATION_MS } from '@/lib/constants';
+
+describe('useAnimatingItems', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initial state', () => {
+    it('returns opacity 1 for any id', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+
+      expect(result.current.getItemOpacity('any-id')).toBe(1);
+      expect(result.current.getItemOpacity('another-id')).toBe(1);
+      expect(result.current.getItemOpacity('')).toBe(1);
+    });
+  });
+
+  describe('startFadeOut', () => {
+    it('sets opacity to 0 for the item', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+      const onComplete = vi.fn();
+
+      act(() => {
+        result.current.startFadeOut('item-1', onComplete);
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+    });
+
+    it('calls onComplete callback after ANIMATION_DURATION_MS', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+      const onComplete = vi.fn();
+
+      act(() => {
+        result.current.startFadeOut('item-1', onComplete);
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION_MS);
+      });
+
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onComplete before ANIMATION_DURATION_MS', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+      const onComplete = vi.fn();
+
+      act(() => {
+        result.current.startFadeOut('item-1', onComplete);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION_MS - 1);
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('startFadeIn', () => {
+    it('sets opacity to 1 for the item with fadeIn animation', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+
+      act(() => {
+        result.current.startFadeIn('item-1');
+      });
+
+      // fadeIn type returns opacity 1
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+
+    it('replaces existing animation for the same id', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+      const onComplete = vi.fn();
+
+      act(() => {
+        result.current.startFadeOut('item-1', onComplete);
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+
+      act(() => {
+        result.current.startFadeIn('item-1');
+      });
+
+      // fadeIn replaces the fadeOut, so opacity should be 1
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+
+    it('auto-clears animation after ANIMATION_DURATION_MS', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+
+      act(() => {
+        result.current.startFadeIn('item-1');
+      });
+
+      // The item has a fadeIn animation entry
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION_MS);
+      });
+
+      // After the timer, the animation entry is removed;
+      // getItemOpacity returns 1 for items without animation entries
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+  });
+
+  describe('clearAnimation', () => {
+    it('removes animation for the specified id', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+      const onComplete = vi.fn();
+
+      act(() => {
+        result.current.startFadeOut('item-1', onComplete);
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+
+      act(() => {
+        result.current.clearAnimation('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+    });
+
+    it('does not affect other animations', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+
+      act(() => {
+        result.current.startFadeOut('item-1', vi.fn());
+        result.current.startFadeOut('item-2', vi.fn());
+      });
+
+      act(() => {
+        result.current.clearAnimation('item-1');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(1);
+      expect(result.current.getItemOpacity('item-2')).toBe(0);
+    });
+  });
+
+  describe('multiple animations', () => {
+    it('can track multiple items independently', () => {
+      const { result } = renderHook(() => useAnimatingItems());
+      const onComplete1 = vi.fn();
+      const onComplete2 = vi.fn();
+
+      act(() => {
+        result.current.startFadeOut('item-1', onComplete1);
+      });
+
+      act(() => {
+        result.current.startFadeIn('item-2');
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+      expect(result.current.getItemOpacity('item-2')).toBe(1);
+      expect(result.current.getItemOpacity('item-3')).toBe(1);
+
+      act(() => {
+        result.current.startFadeOut('item-3', onComplete2);
+      });
+
+      expect(result.current.getItemOpacity('item-1')).toBe(0);
+      expect(result.current.getItemOpacity('item-2')).toBe(1);
+      expect(result.current.getItemOpacity('item-3')).toBe(0);
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('clears all timers when unmounted', () => {
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+      const { result, unmount } = renderHook(() => useAnimatingItems());
+
+      act(() => {
+        result.current.startFadeOut('item-1', vi.fn());
+        result.current.startFadeIn('item-2');
+      });
+
+      const clearTimeoutCallsBefore = clearTimeoutSpy.mock.calls.length;
+
+      unmount();
+
+      // clearTimeout should have been called for each pending timer
+      const clearTimeoutCallsAfter = clearTimeoutSpy.mock.calls.length;
+      expect(clearTimeoutCallsAfter).toBeGreaterThan(clearTimeoutCallsBefore);
+
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('does not fire callbacks after unmount', () => {
+      const onComplete = vi.fn();
+      const { result, unmount } = renderHook(() => useAnimatingItems());
+
+      act(() => {
+        result.current.startFadeOut('item-1', onComplete);
+      });
+
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION_MS);
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/hooks/useArchiveToast.test.tsx
+++ b/tests/hooks/useArchiveToast.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useArchiveToast } from '@/hooks/useArchiveToast';
+
+describe('useArchiveToast', () => {
+  describe('initial state', () => {
+    it('returns toast with visible set to false', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      expect(result.current.toast.visible).toBe(false);
+    });
+
+    it('returns toast with empty pageId', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      expect(result.current.toast.pageId).toBe('');
+    });
+
+    it('returns toast with empty pageTitle', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      expect(result.current.toast.pageTitle).toBe('');
+    });
+
+    it('returns showToast and hideToast functions', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      expect(typeof result.current.showToast).toBe('function');
+      expect(typeof result.current.hideToast).toBe('function');
+    });
+  });
+
+  describe('showToast', () => {
+    it('sets visible to true', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'My Page');
+      });
+
+      expect(result.current.toast.visible).toBe(true);
+    });
+
+    it('stores the provided pageId', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'My Page');
+      });
+
+      expect(result.current.toast.pageId).toBe('page-1');
+    });
+
+    it('stores the provided pageTitle', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'My Page');
+      });
+
+      expect(result.current.toast.pageTitle).toBe('My Page');
+    });
+  });
+
+  describe('hideToast', () => {
+    it('sets visible to false', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'My Page');
+      });
+
+      act(() => {
+        result.current.hideToast();
+      });
+
+      expect(result.current.toast.visible).toBe(false);
+    });
+
+    it('clears pageId to empty string', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'My Page');
+      });
+
+      act(() => {
+        result.current.hideToast();
+      });
+
+      expect(result.current.toast.pageId).toBe('');
+    });
+
+    it('clears pageTitle to empty string', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'My Page');
+      });
+
+      act(() => {
+        result.current.hideToast();
+      });
+
+      expect(result.current.toast.pageTitle).toBe('');
+    });
+  });
+
+  describe('show then hide sequence', () => {
+    it('transitions from visible to hidden with state fully reset', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-abc', 'Meeting Notes');
+      });
+
+      expect(result.current.toast).toEqual({
+        visible: true,
+        pageId: 'page-abc',
+        pageTitle: 'Meeting Notes',
+      });
+
+      act(() => {
+        result.current.hideToast();
+      });
+
+      expect(result.current.toast).toEqual({
+        visible: false,
+        pageId: '',
+        pageTitle: '',
+      });
+    });
+
+    it('returns to the same state as initial after hide', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      const initialToast = { ...result.current.toast };
+
+      act(() => {
+        result.current.showToast('page-1', 'Some Title');
+      });
+
+      act(() => {
+        result.current.hideToast();
+      });
+
+      expect(result.current.toast).toEqual(initialToast);
+    });
+  });
+
+  describe('showing different toasts sequentially', () => {
+    it('overwrites previous toast state with new values', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'First Page');
+      });
+
+      expect(result.current.toast).toEqual({
+        visible: true,
+        pageId: 'page-1',
+        pageTitle: 'First Page',
+      });
+
+      act(() => {
+        result.current.showToast('page-2', 'Second Page');
+      });
+
+      expect(result.current.toast).toEqual({
+        visible: true,
+        pageId: 'page-2',
+        pageTitle: 'Second Page',
+      });
+    });
+
+    it('does not retain any data from the previous toast', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('id-aaa', 'Title AAA');
+      });
+
+      act(() => {
+        result.current.showToast('id-bbb', 'Title BBB');
+      });
+
+      expect(result.current.toast.pageId).not.toBe('id-aaa');
+      expect(result.current.toast.pageTitle).not.toBe('Title AAA');
+      expect(result.current.toast.pageId).toBe('id-bbb');
+      expect(result.current.toast.pageTitle).toBe('Title BBB');
+    });
+
+    it('keeps visible as true when showing multiple toasts in a row', () => {
+      const { result } = renderHook(() => useArchiveToast());
+
+      act(() => {
+        result.current.showToast('page-1', 'First');
+      });
+
+      act(() => {
+        result.current.showToast('page-2', 'Second');
+      });
+
+      act(() => {
+        result.current.showToast('page-3', 'Third');
+      });
+
+      expect(result.current.toast.visible).toBe(true);
+      expect(result.current.toast.pageId).toBe('page-3');
+      expect(result.current.toast.pageTitle).toBe('Third');
+    });
+  });
+});

--- a/tests/hooks/useArchives.test.tsx
+++ b/tests/hooks/useArchives.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useArchives } from '@/hooks/useArchives';
+import type { ArchiveListItem } from '@/lib/types';
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    logResponseError: vi.fn(),
+  };
+});
+
+vi.stubGlobal('fetch', vi.fn());
+
+const mockFetch = fetch as ReturnType<typeof vi.fn>;
+
+function createArchive(
+  overrides: Partial<ArchiveListItem> = {},
+): ArchiveListItem {
+  return {
+    id: 'archive-1',
+    title: 'Test Archive',
+    created_at: 1000,
+    updated_at: 2000,
+    archived_at: 3000,
+    ...overrides,
+  };
+}
+
+function okJsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as Response;
+}
+
+function errorResponse(status: number, statusText: string): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(''),
+  } as Response;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useArchives', () => {
+  describe('fetchArchives', () => {
+    it('successful fetch sets archives state', async () => {
+      const archives: ArchiveListItem[] = [
+        createArchive({ id: 'a-1', title: 'First' }),
+        createArchive({ id: 'a-2', title: 'Second' }),
+      ];
+      mockFetch.mockResolvedValueOnce(okJsonResponse(archives));
+
+      const { result } = renderHook(() => useArchives());
+
+      expect(result.current.archives).toEqual([]);
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/archives');
+      expect(result.current.archives).toEqual(archives);
+    });
+
+    it('handles non-ok response', async () => {
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(500, 'Internal Server Error'),
+      );
+
+      const { result } = renderHook(() => useArchives());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      expect(result.current.archives).toEqual([]);
+    });
+
+    it('handles invalid response shape', async () => {
+      const invalidData = { not: 'an array' };
+      mockFetch.mockResolvedValueOnce(okJsonResponse(invalidData));
+
+      const { result } = renderHook(() => useArchives());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      expect(result.current.archives).toEqual([]);
+    });
+
+    it('handles network error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+      const { result } = renderHook(() => useArchives());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      expect(result.current.archives).toEqual([]);
+    });
+  });
+
+  describe('archivePage', () => {
+    it('successful archive returns archived_at timestamp', async () => {
+      const archivedAt = Date.now();
+      mockFetch.mockResolvedValueOnce(
+        okJsonResponse({ archived_at: archivedAt }),
+      );
+
+      const { result } = renderHook(() => useArchives());
+
+      let returnValue: number | null = null;
+      await act(async () => {
+        returnValue = await result.current.archivePage('page-1');
+      });
+
+      expect(returnValue).toBe(archivedAt);
+      expect(mockFetch).toHaveBeenCalledWith('/api/pages/page-1/archive', {
+        method: 'POST',
+      });
+    });
+
+    it('handles non-ok response, returns null', async () => {
+      mockFetch.mockResolvedValueOnce(errorResponse(404, 'Not Found'));
+
+      const { result } = renderHook(() => useArchives());
+
+      let returnValue: number | null = 999;
+      await act(async () => {
+        returnValue = await result.current.archivePage('non-existent');
+      });
+
+      expect(returnValue).toBeNull();
+    });
+
+    it('handles invalid response shape, returns null', async () => {
+      const invalidData = { wrong_field: 'value' };
+      mockFetch.mockResolvedValueOnce(okJsonResponse(invalidData));
+
+      const { result } = renderHook(() => useArchives());
+
+      let returnValue: number | null = 999;
+      await act(async () => {
+        returnValue = await result.current.archivePage('page-1');
+      });
+
+      expect(returnValue).toBeNull();
+    });
+
+    it('handles network error, returns null', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+      const { result } = renderHook(() => useArchives());
+
+      let returnValue: number | null = 999;
+      await act(async () => {
+        returnValue = await result.current.archivePage('page-1');
+      });
+
+      expect(returnValue).toBeNull();
+    });
+  });
+
+  describe('unarchivePage', () => {
+    it('successful unarchive returns true', async () => {
+      mockFetch.mockResolvedValueOnce(okJsonResponse({ success: true }));
+
+      const { result } = renderHook(() => useArchives());
+
+      let returnValue = false;
+      await act(async () => {
+        returnValue = await result.current.unarchivePage('page-1');
+      });
+
+      expect(returnValue).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith('/api/pages/page-1/unarchive', {
+        method: 'POST',
+      });
+    });
+
+    it('handles non-ok response, returns false', async () => {
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(500, 'Internal Server Error'),
+      );
+
+      const { result } = renderHook(() => useArchives());
+
+      let returnValue = true;
+      await act(async () => {
+        returnValue = await result.current.unarchivePage('page-1');
+      });
+
+      expect(returnValue).toBe(false);
+    });
+
+    it('handles network error, returns false', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+      const { result } = renderHook(() => useArchives());
+
+      let returnValue = true;
+      await act(async () => {
+        returnValue = await result.current.unarchivePage('page-1');
+      });
+
+      expect(returnValue).toBe(false);
+    });
+  });
+
+  describe('addArchive', () => {
+    it('adds an archive to the beginning of the list', async () => {
+      const existing: ArchiveListItem[] = [
+        createArchive({ id: 'a-1', title: 'Existing' }),
+      ];
+      mockFetch.mockResolvedValueOnce(okJsonResponse(existing));
+
+      const { result } = renderHook(() => useArchives());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      const newArchive = createArchive({ id: 'a-2', title: 'New Archive' });
+
+      act(() => {
+        result.current.addArchive(newArchive);
+      });
+
+      expect(result.current.archives).toHaveLength(2);
+      expect(result.current.archives[0]).toEqual(newArchive);
+      expect(result.current.archives[1]).toEqual(existing[0]);
+    });
+  });
+
+  describe('removeArchive', () => {
+    it('removes an archive from the list', async () => {
+      const archives: ArchiveListItem[] = [
+        createArchive({ id: 'a-1', title: 'First' }),
+        createArchive({ id: 'a-2', title: 'Second' }),
+        createArchive({ id: 'a-3', title: 'Third' }),
+      ];
+      mockFetch.mockResolvedValueOnce(okJsonResponse(archives));
+
+      const { result } = renderHook(() => useArchives());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      act(() => {
+        result.current.removeArchive('a-2');
+      });
+
+      expect(result.current.archives).toHaveLength(2);
+      expect(result.current.archives.map((a) => a.id)).toEqual(['a-1', 'a-3']);
+    });
+  });
+
+  describe('findArchive', () => {
+    it('finds an archive by id', async () => {
+      const target = createArchive({ id: 'a-2', title: 'Target' });
+      const archives: ArchiveListItem[] = [
+        createArchive({ id: 'a-1', title: 'First' }),
+        target,
+        createArchive({ id: 'a-3', title: 'Third' }),
+      ];
+      mockFetch.mockResolvedValueOnce(okJsonResponse(archives));
+
+      const { result } = renderHook(() => useArchives());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      const found = result.current.findArchive('a-2');
+      expect(found).toEqual(target);
+    });
+
+    it('returns undefined for non-existent id', async () => {
+      const archives: ArchiveListItem[] = [
+        createArchive({ id: 'a-1', title: 'First' }),
+      ];
+      mockFetch.mockResolvedValueOnce(okJsonResponse(archives));
+
+      const { result } = renderHook(() => useArchives());
+
+      await act(async () => {
+        await result.current.fetchArchives();
+      });
+
+      const found = result.current.findArchive('non-existent');
+      expect(found).toBeUndefined();
+    });
+  });
+});

--- a/tests/hooks/usePageList.test.tsx
+++ b/tests/hooks/usePageList.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePageList } from '@/hooks/usePageList';
+import type { PageListItem } from '@/lib/types';
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const mockPages: PageListItem[] = [
+  { id: 'page-1', title: 'First Page', created_at: 1000, updated_at: 2000 },
+  { id: 'page-2', title: 'Second Page', created_at: 1500, updated_at: 2500 },
+];
+
+function createFetchResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Internal Server Error',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('usePageList', () => {
+  describe('fetchPages', () => {
+    it('successful fetch sets pages state', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(mockPages)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      expect(result.current.pages).toEqual([]);
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toEqual(mockPages);
+      expect(fetch).toHaveBeenCalledWith('/api/pages');
+    });
+
+    it('handles non-ok response', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse({}, false, 500)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toEqual([]);
+    });
+
+    it('handles invalid response shape', async () => {
+      const invalidData = { not: 'an array' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(invalidData)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toEqual([]);
+    });
+
+    it('handles network error', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new Error('Network failure')),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toEqual([]);
+    });
+  });
+
+  describe('createPage', () => {
+    it('successful create returns page id', async () => {
+      const createResponse = { id: 'new-page-id' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(createResponse)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+      let pageId: string | null = null;
+
+      await act(async () => {
+        pageId = await result.current.createPage();
+      });
+
+      expect(pageId).toBe('new-page-id');
+      expect(fetch).toHaveBeenCalledWith('/api/pages', { method: 'POST' });
+    });
+
+    it('handles non-ok response, returns null', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse({}, false, 500)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+      let pageId: string | null = 'should-become-null';
+
+      await act(async () => {
+        pageId = await result.current.createPage();
+      });
+
+      expect(pageId).toBeNull();
+    });
+
+    it('handles invalid response shape, returns null', async () => {
+      const invalidData = { name: 'not-an-id-field' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(invalidData)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+      let pageId: string | null = 'should-become-null';
+
+      await act(async () => {
+        pageId = await result.current.createPage();
+      });
+
+      expect(pageId).toBeNull();
+    });
+
+    it('handles network error, returns null', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new Error('Network failure')),
+      );
+
+      const { result } = renderHook(() => usePageList());
+      let pageId: string | null = 'should-become-null';
+
+      await act(async () => {
+        pageId = await result.current.createPage();
+      });
+
+      expect(pageId).toBeNull();
+    });
+  });
+
+  describe('removePage', () => {
+    it('removes a page from the list', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(mockPages)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      expect(result.current.pages).toHaveLength(2);
+
+      act(() => {
+        result.current.removePage('page-1');
+      });
+
+      expect(result.current.pages).toHaveLength(1);
+      expect(result.current.pages[0].id).toBe('page-2');
+    });
+  });
+
+  describe('addPage', () => {
+    it('adds a page to the beginning of the list', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(mockPages)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      const newPage: PageListItem = {
+        id: 'page-3',
+        title: 'Third Page',
+        created_at: 3000,
+        updated_at: 3500,
+      };
+
+      act(() => {
+        result.current.addPage(newPage);
+      });
+
+      expect(result.current.pages).toHaveLength(3);
+      expect(result.current.pages[0]).toEqual(newPage);
+      expect(result.current.pages[1]).toEqual(mockPages[0]);
+      expect(result.current.pages[2]).toEqual(mockPages[1]);
+    });
+  });
+
+  describe('findPage', () => {
+    it('finds a page by id', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(mockPages)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      const found = result.current.findPage('page-2');
+      expect(found).toEqual(mockPages[1]);
+    });
+
+    it('returns undefined for non-existent id', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(createFetchResponse(mockPages)),
+      );
+
+      const { result } = renderHook(() => usePageList());
+
+      await act(async () => {
+        await result.current.fetchPages();
+      });
+
+      const found = result.current.findPage('non-existent');
+      expect(found).toBeUndefined();
+    });
+  });
+});

--- a/tests/hooks/useSaveContent.test.tsx
+++ b/tests/hooks/useSaveContent.test.tsx
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSaveContent } from '@/hooks/useSaveContent';
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  logResponseError: vi.fn().mockResolvedValue(''),
+}));
+
+function createFetchResponse(
+  ok: boolean,
+  status: number,
+  statusText?: string,
+): Response {
+  return {
+    ok,
+    status,
+    statusText: statusText ?? (ok ? 'OK' : 'Internal Server Error'),
+    text: () => Promise.resolve(''),
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('useSaveContent', () => {
+  it('returns null as initial saveError', () => {
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    expect(result.current.saveError).toBeNull();
+  });
+
+  it('calls fetch with correct params after 1 second debounce on content change', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(createFetchResponse(true, 200));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    act(() => {
+      result.current.handleContentChange('Hello, world!');
+    });
+
+    // fetch should not be called immediately
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // Advance past the 1000ms debounce
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('/api/pages/page-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content: 'Hello, world!' }),
+    });
+  });
+
+  it('clears any existing save error on successful save', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    // First call fails, second call succeeds
+    mockFetch
+      .mockResolvedValueOnce(createFetchResponse(false, 500))
+      .mockResolvedValueOnce(createFetchResponse(true, 200));
+
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    // Trigger a failed save first
+    act(() => {
+      result.current.handleContentChange('fail content');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.saveError).toBe('保存に失敗しました');
+
+    // Now trigger a successful save
+    act(() => {
+      result.current.handleContentChange('success content');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.saveError).toBeNull();
+  });
+
+  it('sets saveError to generic message on non-ok response', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(createFetchResponse(false, 500));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    act(() => {
+      result.current.handleContentChange('some content');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.saveError).toBe('保存に失敗しました');
+  });
+
+  it('sets saveError to size limit message on 413 status', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(createFetchResponse(false, 413, 'Payload Too Large'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    act(() => {
+      result.current.handleContentChange('very large content');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.saveError).toBe(
+      '保存できませんでした: コンテンツが大きすぎます（上限: 10MB）',
+    );
+  });
+
+  it('sets saveError on network error', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network failure'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    act(() => {
+      result.current.handleContentChange('some content');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.saveError).toBe('保存に失敗しました');
+  });
+
+  it('debounces multiple rapid changes and only triggers one save', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(createFetchResponse(true, 200));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    // Simulate rapid typing: multiple changes within the debounce window
+    act(() => {
+      result.current.handleContentChange('H');
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => {
+      result.current.handleContentChange('He');
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => {
+      result.current.handleContentChange('Hel');
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => {
+      result.current.handleContentChange('Hell');
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => {
+      result.current.handleContentChange('Hello');
+    });
+
+    // No fetch should have been called yet
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // Advance past the debounce window from the last change
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Only one fetch call with the final content
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('/api/pages/page-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content: 'Hello' }),
+    });
+  });
+
+  it('auto-dismisses save error after 5 seconds', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(createFetchResponse(false, 500));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { result } = renderHook(() => useSaveContent('page-1'));
+
+    act(() => {
+      result.current.handleContentChange('some content');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.saveError).toBe('保存に失敗しました');
+
+    // Advance 4999ms - error should still be visible
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+
+    expect(result.current.saveError).toBe('保存に失敗しました');
+
+    // Advance the remaining 1ms to reach 5000ms total
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.saveError).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
   },
 });


### PR DESCRIPTION
Extract API calls, state management, and animation logic from PageBoard.tsx
and MarkdownEditor.tsx into reusable custom hooks to improve testability
and maintainability.

New hooks:
- usePageList: page list fetching, creation, and local state management
- useArchives: archive list fetching, archive/unarchive API, local state
- useAnimatingItems: fade-in/fade-out animation state with timer cleanup
- useArchiveToast: toast notification state for archive actions
- useSaveContent: debounced content save with error handling

Changes:
- PageBoard.tsx refactored to compose hooks for UI rendering
- MarkdownEditor.tsx save logic extracted to useSaveContent hook
- Added 62 unit tests for all extracted hooks
- Added @testing-library/react and jsdom for hook testing

https://claude.ai/code/session_01AYe6qMwowQySxpNjnZH4VR