### PR TITLE
fix: ビルド時のSQLite BUSY エラーを修正

### DIFF
--- a/app/api/archives/route.ts
+++ b/app/api/archives/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
-import db from '@/lib/db';
+import getDb from '@/lib/db';
 import { logger } from '@/lib/logger';
 
 import { cleanupOldArchives } from '@/server/cleanup-archives';
 
 export async function GET() {
   try {
+    const db = getDb();
     const stmt = db.prepare(`
       SELECT id, title, created_at, updated_at, archived_at
       FROM pages
@@ -26,6 +27,7 @@ export async function GET() {
 
 export async function DELETE() {
   try {
+    const db = getDb();
     const deleted = cleanupOldArchives(db);
 
     return NextResponse.json({ success: true, deleted });

--- a/app/api/pages/[id]/archive/route.ts
+++ b/app/api/pages/[id]/archive/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import db from '@/lib/db';
+import getDb from '@/lib/db';
 import { logger } from '@/lib/logger';
 
 export async function POST(
@@ -7,6 +7,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    const db = getDb();
     const { id } = await params;
     const now = Date.now();
 

--- a/app/api/pages/[id]/route.ts
+++ b/app/api/pages/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import db from '@/lib/db';
+import getDb from '@/lib/db';
 import { logger } from '@/lib/logger';
 
 export async function GET(
@@ -7,6 +7,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    const db = getDb();
     const { id } = await params;
 
     const stmt = db.prepare(`
@@ -36,6 +37,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    const db = getDb();
     const { id } = await params;
 
     const deleteTransaction = db.transaction(() => {

--- a/app/api/pages/[id]/unarchive/route.ts
+++ b/app/api/pages/[id]/unarchive/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import db from '@/lib/db';
+import getDb from '@/lib/db';
 import { logger } from '@/lib/logger';
 
 export async function POST(
@@ -7,6 +7,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    const db = getDb();
     const { id } = await params;
 
     const stmt = db.prepare(`

--- a/app/api/pages/route.ts
+++ b/app/api/pages/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { uuidv7 } from 'uuidv7';
-import db from '@/lib/db';
+import getDb from '@/lib/db';
 import { logger } from '@/lib/logger';
 
 export async function GET() {
   try {
+    const db = getDb();
     const stmt = db.prepare(`
       SELECT id, title, created_at, updated_at
       FROM pages
@@ -25,6 +26,7 @@ export async function GET() {
 
 export async function POST() {
   try {
+    const db = getDb();
     const id = uuidv7();
     const now = Date.now();
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,37 +1,44 @@
+import type Database from 'better-sqlite3';
 import { openDatabase } from '../server/db-config';
 
-const db = openDatabase();
+let _db: Database.Database | undefined;
 
-// Initialize database schema
-db.exec(`
-  CREATE TABLE IF NOT EXISTS pages (
-    id TEXT PRIMARY KEY,
-    title TEXT NOT NULL DEFAULT 'Untitled',
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL,
-    archived_at INTEGER
-  );
+export default function getDb(): Database.Database {
+  if (_db) return _db;
 
-  CREATE INDEX IF NOT EXISTS idx_pages_archived_at ON pages(archived_at);
-  CREATE INDEX IF NOT EXISTS idx_pages_created_at ON pages(created_at);
-  CREATE INDEX IF NOT EXISTS idx_pages_updated_at ON pages(updated_at);
+  _db = openDatabase();
 
-  CREATE TABLE IF NOT EXISTS yjs_updates (
-    doc_name TEXT NOT NULL,
-    clock INTEGER NOT NULL,
-    value BLOB NOT NULL,
-    PRIMARY KEY (doc_name, clock)
-  );
-`);
+  // Initialize database schema
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS pages (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT 'Untitled',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      archived_at INTEGER
+    );
 
-// Migration: drop content column if it exists (from pre-Yjs schema)
-const hasContentColumn = db
-  .prepare(
-    "SELECT COUNT(*) as cnt FROM pragma_table_info('pages') WHERE name='content'",
-  )
-  .get() as { cnt: number };
-if (hasContentColumn.cnt > 0) {
-  db.exec('ALTER TABLE pages DROP COLUMN content');
+    CREATE INDEX IF NOT EXISTS idx_pages_archived_at ON pages(archived_at);
+    CREATE INDEX IF NOT EXISTS idx_pages_created_at ON pages(created_at);
+    CREATE INDEX IF NOT EXISTS idx_pages_updated_at ON pages(updated_at);
+
+    CREATE TABLE IF NOT EXISTS yjs_updates (
+      doc_name TEXT NOT NULL,
+      clock INTEGER NOT NULL,
+      value BLOB NOT NULL,
+      PRIMARY KEY (doc_name, clock)
+    );
+  `);
+
+  // Migration: drop content column if it exists (from pre-Yjs schema)
+  const hasContentColumn = _db
+    .prepare(
+      "SELECT COUNT(*) as cnt FROM pragma_table_info('pages') WHERE name='content'",
+    )
+    .get() as { cnt: number };
+  if (hasContentColumn.cnt > 0) {
+    _db.exec('ALTER TABLE pages DROP COLUMN content');
+  }
+
+  return _db;
 }
-
-export default db;


### PR DESCRIPTION
lib/db.ts がモジュール評価時に openDatabase() を即時実行していたため、
Next.js ビルドの "Collecting page data" フェーズで15個のワーカーが
同時にSQLiteデータベースを開こうとし SQLITE_BUSY エラーが発生していた。

データベースの初期化を遅延実行（lazy initialization）に変更し、
実際にAPIハンドラが呼ばれた時点で初めてDBを開くようにした。

https://claude.ai/code/session_01RDjio4BxBSdjzX4n9JmU7T