### PR TITLE
fix: 箇条書きリストのビュレットポイントを表示する

### DIFF
--- a/app/milkdown.css
+++ b/app/milkdown.css
@@ -38,8 +38,15 @@
   color: #574a46;
 }
 
-.milkdown ul,
+.milkdown ul {
+  list-style-type: disc;
+  margin-bottom: 1rem;
+  padding-left: 2rem;
+  color: #574a46;
+}
+
 .milkdown ol {
+  list-style-type: decimal;
   margin-bottom: 1rem;
   padding-left: 2rem;
   color: #574a46;


### PR DESCRIPTION
Tailwind CSS v4のプリフライトがlist-style: noneをグローバルに
適用するため、milkdown.cssでlist-style-typeを明示的に設定して
リストマーカーを復元する。

- ul要素にlist-style-type: discを追加
- ol要素にlist-style-type: decimalを追加

Closes #141

https://claude.ai/code/session_01SiSzyr3UrVEzkrxLrFvcYB