### PR TITLE
左ペインのスクロールバーをカスタムスタイルに変更

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,3 +130,26 @@ body {
   outline-offset: 2px;
   background-color: var(--accent-light-focus-bg);
 }
+
+/* Sidebar scrollbar */
+.sidebar-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--foreground-rgb), 0.2) transparent;
+}
+
+.sidebar-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidebar-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar-scroll::-webkit-scrollbar-thumb {
+  background-color: rgba(var(--foreground-rgb), 0.2);
+  border-radius: 3px;
+}
+
+.sidebar-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(var(--foreground-rgb), 0.35);
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -267,7 +267,10 @@ export default function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
       </div>
 
       {/* Scrollable content area */}
-      <div className="flex-1 overflow-y-auto" style={{ padding: '16px' }}>
+      <div
+        className="sidebar-scroll flex-1 overflow-y-auto"
+        style={{ padding: '16px' }}
+      >
         {loading ? (
           <div style={{ color: 'var(--foreground)', padding: '20px' }}>
             読み込み中...


### PR DESCRIPTION
サイドバーのスクロール領域に細くて丸みのあるスクロールバーを適用。
WebKit系ブラウザとFirefox両方に対応。

closes #142

https://claude.ai/code/session_01VzLfX3fmC3qQUEyGkjTk1a