### PR TITLE
Add search functionality to archive tab in Sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -76,6 +76,7 @@ export default function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
   const [activeTab, setActiveTab] = useState<Tab>('latest');
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
+  const [archiveSearchQuery, setArchiveSearchQuery] = useState('');
   const [now, setNow] = useState(() => Date.now());
   const router = useRouter();
   const params = useParams();
@@ -109,6 +110,12 @@ export default function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
     const query = searchQuery.toLowerCase();
     return pages.filter((page) => page.title.toLowerCase().includes(query));
   }, [pages, searchQuery]);
+
+  const filteredArchives = useMemo(() => {
+    if (!archiveSearchQuery) return archives;
+    const query = archiveSearchQuery.toLowerCase();
+    return archives.filter((page) => page.title.toLowerCase().includes(query));
+  }, [archives, archiveSearchQuery]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -392,14 +399,36 @@ export default function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
                 >
                   30日間保持されます
                 </p>
-                {archives.length === 0 ? (
+                <div style={{ marginBottom: '12px' }}>
+                  <input
+                    type="text"
+                    value={archiveSearchQuery}
+                    onChange={(e) => setArchiveSearchQuery(e.target.value)}
+                    placeholder="アーカイブを検索..."
+                    aria-label="アーカイブを検索"
+                    style={{
+                      width: '100%',
+                      padding: '10px 12px',
+                      fontSize: '13px',
+                      border: '1px solid rgba(var(--foreground-rgb), 0.15)',
+                      borderRadius: '8px',
+                      backgroundColor: 'rgba(var(--foreground-rgb), 0.05)',
+                      color: 'var(--foreground)',
+                      outline: 'none',
+                      boxSizing: 'border-box',
+                    }}
+                  />
+                </div>
+                {filteredArchives.length === 0 ? (
                   <p
                     style={{
                       color: 'var(--foreground-muted)',
                       fontSize: '13px',
                     }}
                   >
-                    アーカイブされたページはありません。
+                    {archiveSearchQuery
+                      ? '一致するページが見つかりません。'
+                      : 'アーカイブされたページはありません。'}
                   </p>
                 ) : (
                   <div
@@ -409,7 +438,7 @@ export default function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
                       gap: '8px',
                     }}
                   >
-                    {archives.map((page) => (
+                    {filteredArchives.map((page) => (
                       <PageListItem
                         key={page.id}
                         dataTestId={`archive-item-${page.id}`}

--- a/tests/components/Sidebar.test.tsx
+++ b/tests/components/Sidebar.test.tsx
@@ -317,6 +317,79 @@ describe('Sidebar', () => {
     });
   });
 
+  describe('archive search', () => {
+    it('shows search field on archive tab', async () => {
+      mockArchives = makeArchives(2);
+      await renderSidebar();
+
+      const archiveTab = screen.getByRole('tab', { name: 'アーカイブ' });
+      await act(async () => {
+        fireEvent.click(archiveTab);
+      });
+
+      expect(screen.getByLabelText('アーカイブを検索')).toBeTruthy();
+    });
+
+    it('filters archives by search query', async () => {
+      mockArchives = makeArchives(3);
+      await renderSidebar();
+
+      const archiveTab = screen.getByRole('tab', { name: 'アーカイブ' });
+      await act(async () => {
+        fireEvent.click(archiveTab);
+      });
+
+      const searchInput = screen.getByLabelText('アーカイブを検索');
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: 'Archived 1' } });
+      });
+
+      expect(screen.getByText('Archived 1')).toBeTruthy();
+      expect(screen.queryByText('Archived 2')).toBeNull();
+    });
+
+    it('shows no-results message when archive search matches nothing', async () => {
+      mockArchives = makeArchives(2);
+      await renderSidebar();
+
+      const archiveTab = screen.getByRole('tab', { name: 'アーカイブ' });
+      await act(async () => {
+        fireEvent.click(archiveTab);
+      });
+
+      const searchInput = screen.getByLabelText('アーカイブを検索');
+      await act(async () => {
+        fireEvent.change(searchInput, {
+          target: { value: 'zzz-nonexistent' },
+        });
+      });
+
+      expect(screen.getByText('一致するページが見つかりません。')).toBeTruthy();
+    });
+
+    it('shows all archives when search is cleared', async () => {
+      mockArchives = makeArchives(3);
+      await renderSidebar();
+
+      const archiveTab = screen.getByRole('tab', { name: 'アーカイブ' });
+      await act(async () => {
+        fireEvent.click(archiveTab);
+      });
+
+      const searchInput = screen.getByLabelText('アーカイブを検索');
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: 'Archived 1' } });
+      });
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: '' } });
+      });
+
+      for (let i = 1; i <= 3; i++) {
+        expect(screen.getByText(`Archived ${i}`)).toBeTruthy();
+      }
+    });
+  });
+
   describe('page list rendering', () => {
     it('renders page items with correct data-testid', async () => {
       mockPages = makePages(2);


### PR DESCRIPTION
## Summary
Added search capability to the archive tab in the Sidebar component, allowing users to filter archived pages by title.

## Key Changes
- Added `archiveSearchQuery` state to track the archive search input value
- Created `filteredArchives` computed value using `useMemo` to filter archives based on search query (case-insensitive title matching)
- Added a search input field in the archive tab with proper styling and accessibility attributes
- Updated empty state messaging to distinguish between "no archives exist" and "no search results found"
- Updated archive list rendering to use `filteredArchives` instead of the full `archives` array
- Added comprehensive test coverage with 4 new test cases covering:
  - Search field visibility on archive tab
  - Filtering functionality
  - No-results messaging
  - Search clearing behavior

## Implementation Details
- Search is case-insensitive and matches against archive page titles
- Search input includes proper `aria-label` for accessibility
- Styling matches the existing design system with consistent padding, borders, and colors
- Empty state message dynamically changes based on whether a search query is active

https://claude.ai/code/session_014heDHtqKU8zZP3zbpiPzwM