### PR TITLE
Fix tab button focus outline offset for better visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -139,7 +139,7 @@ body {
 
 .tab-button:focus-visible {
   outline: 3px solid var(--accent);
-  outline-offset: -2px;
+  outline-offset: 2px;
   background-color: var(--accent-focus-bg);
 }
 


### PR DESCRIPTION
## Summary
Adjusted the focus outline offset for tab buttons to improve visual accessibility and consistency with standard focus indicator patterns.

## Changes
- Changed `.tab-button:focus-visible` outline-offset from `-2px` (inset) to `2px` (outset)
  - This moves the focus outline outside the button element instead of inside it
  - Improves visibility of the focus indicator for keyboard navigation
  - Aligns with common accessibility practices for focus states

## Details
The outline-offset property controls the space between an element's outline and its border edge. The previous negative value (`-2px`) created an inset outline that could be obscured by the button's background color. The new positive value (`2px`) creates an outset outline that is more visible and provides clearer visual feedback to users navigating via keyboard.

https://claude.ai/code/session_019wPw4Gfibruk8XxrReuXLN